### PR TITLE
Fixed bug in aggregation of responses in chunked bulk requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.swp
+vendor/
+composer.*

--- a/README.markdown
+++ b/README.markdown
@@ -23,7 +23,7 @@ ElasticSearch is a distributed lucene powered search indexing, this is a PHP cli
 
 ```php
 <?php
-require_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/vendor/composer/autoload.php';
 
 use \ElasticSearch\Client;
 // The recommended way to go about things is to use an environment variable called ELASTICSEARCH_URL

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,1 +1,1 @@
-./vendor/bin/atoum --ulr -d tests/units
+./vendor/composer/bin/atoum --ulr -d tests/units

--- a/src/ElasticSearch/Bulk.php
+++ b/src/ElasticSearch/Bulk.php
@@ -129,14 +129,19 @@ class Bulk {
         $ret = [
             'errors' => FALSE,
             'items' => [],
+            'took' => 0,
         ];
 
         foreach (array_chunk($this->chunks, $chunksize) as $chunks) {
             $chunkRet = $this->transport->request('/_bulk', 'POST', join("\n", $chunks) . "\n");
             $ret['errors'] = $chunkRet['errors'] ? true : $ret['errors'];
-            foreach($chunkRet['items'] as $retItem) {
-                $ret['items'][] = $retItem;
-            }
+            $ret['items'] = array_merge($ret['items'], $chunkRet['items']);
+
+            // Not clear what 'took' represents (it's undocumented) so 
+            // adding the values together for now until a more useful
+            // option presents itself.
+
+            $ret['took'] += $chunkRet['took'];
         }
 
         $this->chunks = [];

--- a/src/ElasticSearch/Bulk.php
+++ b/src/ElasticSearch/Bulk.php
@@ -132,10 +132,10 @@ class Bulk {
         ];
 
         foreach (array_chunk($this->chunks, $chunksize) as $chunks) {
-            $chunk_ret = $this->transport->request('/_bulk', 'POST', join("\n", $chunks) . "\n");
-            $ret['errors'] = $chunk_ret['errors'] ? true : $ret['errors'];
-            foreach($chunk_ret['items'] as $ret_item) {
-                $ret['items'][] = $ret_item;
+            $chunkRet = $this->transport->request('/_bulk', 'POST', join("\n", $chunks) . "\n");
+            $ret['errors'] = $chunkRet['errors'] ? true : $ret['errors'];
+            foreach($chunkRet['items'] as $retItem) {
+                $ret['items'][] = $retItem;
             }
         }
 

--- a/src/ElasticSearch/Bulk.php
+++ b/src/ElasticSearch/Bulk.php
@@ -126,10 +126,19 @@ class Bulk {
         if (!$this->chunks) return;
         $chunksize = $this->chunksize? $this->chunksize: count($this->chunks);
 
-        $ret = [];
+        $ret = [
+            'errors' => FALSE,
+            'items' => [],
+        ];
+
         foreach (array_chunk($this->chunks, $chunksize) as $chunks) {
-            $ret += $this->transport->request('/_bulk', 'POST', join("\n", $chunks) . "\n");
+            $chunk_ret = $this->transport->request('/_bulk', 'POST', join("\n", $chunks) . "\n");
+            $ret['errors'] = $chunk_ret['errors'] ? true : $ret['errors'];
+            foreach($chunk_ret['items'] as $ret_item) {
+                $ret['items'][] = $ret_item;
+            }
         }
+
         $this->chunks = [];
         return $ret;
     }

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -1,6 +1,6 @@
 <?php
 namespace ElasticSearch\tests;
-require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../vendor/composer/autoload.php';
 require_once __DIR__ . '/Helper.php';
 
 class Base extends \mageekguy\atoum\test

--- a/tests/units/Bulk.php
+++ b/tests/units/Bulk.php
@@ -1,0 +1,133 @@
+<?php
+namespace ElasticSearch\tests\units;
+
+require_once __DIR__ . '/../Base.php';
+
+use ElasticSearch\tests\Helper;
+
+class MockTransport {
+    public function request ($path, $method="GET", $payload=false) {
+        $response = [
+            'took' => 3,
+            'items' => [],
+            'errors' => false,
+        ];
+
+        foreach(array_chunk(explode("\n", trim($payload)), 2) as $operation) {
+            $command = json_decode($operation[0], TRUE);
+
+            $metadata = array_values($command)[0];
+            if (array_key_exists('create', $command)) {
+                $metadata['status'] = 409;
+                $metadata['error'] = 'Document Already Exists';
+                $response['errors'] = true;
+            } else {
+                $metadata['status'] = 200;
+                $metadata['_version'] = 1;
+            }
+
+            $response['items'][] = [ array_keys($command)[0] => $metadata];
+        }
+
+        return $response;
+    }
+}
+
+class Bulk extends \ElasticSearch\tests\Base {
+
+    public function testCommit_singleRequestWithError () {
+        $bulk = new \ElasticSearch\Bulk(new MockTransport(), 'quizlet', 'test', $chunk_size = 3);
+        $bulk->index([ 'name' => 'payload to insert 1' ]);
+        $bulk->create([ 'name' => 'payload to create' ]);
+        $bulk->index([ 'name' => 'payload to insert 2' ]);
+
+        $result = $bulk->commit();
+
+        $this->boolean($result['errors'])->isTrue();
+        $this->array($result)->hasKey('items');
+
+        $item = $result['items'][0];
+        $this->array($item)->hasKey('index');
+        $this->array($item['index'])->notHasKey('error');
+        $this->integer($item['index']['status'])->isEqualTo(200);
+
+        $item = $result['items'][1];
+        $this->array($item)->hasKey('create');
+        $this->array($item['create'])->hasKey('error');
+        $this->integer($item['create']['status'])->isEqualTo(409);
+
+        $item = $result['items'][2];
+        $this->array($item)->hasKey('index');
+        $this->array($item['index'])->notHasKey('error');
+        $this->integer($item['index']['status'])->isEqualTo(200);
+    }
+
+    public function testCommit_chunkedRequestWithError () {
+        $bulk = new \ElasticSearch\Bulk(new MockTransport(), 'quizlet', 'test', $chunk_size = 1);
+        $bulk->index([ 'name' => 'payload to insert 1' ]);
+        $bulk->create([ 'name' => 'payload to create' ]);
+        $bulk->index([ 'name' => 'payload to insert 2' ]);
+
+        $result = $bulk->commit();
+
+        $this->boolean($result['errors'])->isTrue();
+        $this->array($result)->hasKey('items');
+
+        $item = $result['items'][0];
+        $this->array($item)->hasKey('index');
+        $this->array($item['index'])->notHasKey('error');
+        $this->integer($item['index']['status'])->isEqualTo(200);
+
+        $item = $result['items'][1];
+        $this->array($item)->hasKey('create');
+        $this->array($item['create'])->hasKey('error');
+        $this->integer($item['create']['status'])->isEqualTo(409);
+
+        $item = $result['items'][2];
+        $this->array($item)->hasKey('index');
+        $this->array($item['index'])->notHasKey('error');
+        $this->integer($item['index']['status'])->isEqualTo(200);
+    }
+
+    public function testCommit_singleRequestSuccess () {
+        $bulk = new \ElasticSearch\Bulk(new MockTransport(), 'quizlet', 'test', $chunk_size = 2);
+        $bulk->index([ 'name' => 'payload to insert 1' ]);
+        $bulk->index([ 'name' => 'payload to insert 2' ]);
+
+        $result = $bulk->commit();
+
+        $this->boolean($result['errors'])->isFalse();
+        $this->array($result)->hasKey('items');
+
+        $item = $result['items'][0];
+        $this->array($item)->hasKey('index');
+        $this->array($item['index'])->notHasKey('error');
+        $this->integer($item['index']['status'])->isEqualTo(200);
+
+        $item = $result['items'][1];
+        $this->array($item)->hasKey('index');
+        $this->array($item['index'])->notHasKey('error');
+        $this->integer($item['index']['status'])->isEqualTo(200);
+    }
+
+    public function testCommit_chunkedRequestSuccess () {
+        $bulk = new \ElasticSearch\Bulk(new MockTransport(), 'quizlet', 'test', $chunk_size = 1);
+        $bulk->index([ 'name' => 'payload to insert 1' ]);
+        $bulk->index([ 'name' => 'payload to insert 2' ]);
+
+        $result = $bulk->commit();
+
+        $this->boolean($result['errors'])->isFalse();
+        $this->array($result)->hasKey('items');
+
+        $item = $result['items'][0];
+        $this->array($item)->hasKey('index');
+        $this->array($item['index'])->notHasKey('error');
+        $this->integer($item['index']['status'])->isEqualTo(200);
+
+        $item = $result['items'][1];
+        $this->array($item)->hasKey('index');
+        $this->array($item['index'])->notHasKey('error');
+        $this->integer($item['index']['status'])->isEqualTo(200);
+    }
+}

--- a/tests/units/Mapping.php
+++ b/tests/units/Mapping.php
@@ -2,7 +2,7 @@
 
 namespace ElasticSearch\tests\units;
 
-require_once getcwd() . '/vendor/autoload.php';
+require_once getcwd() . '/vendor/composer/autoload.php';
 
 use \mageekguy\atoum;
 


### PR DESCRIPTION
In the case where requests were chunked, the implementation was using a '+=' operator to join the responses. In PHP, this evidently creates the union of the arrays. So any keys in each response after the first that were already contained in a previous response were getting dropped. This change now properly aggregates the 'items' list of the response so that all chunks are kept.

 - [x] reviewed by @chanind 